### PR TITLE
Add base and size to example so it works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ buffer of image data.
 var makizushi = require('makizushi');
 
 makizushi({
+    base: 'pin',
+    size: 'l',
     tint: '333',
     label: 'a'
 }, function(err, buf) {


### PR DESCRIPTION
I couldn't get the example in the README to work. Adding a base and size helped. Looking at the source those aren't optional params.
