### PR TITLE
Bump to 1.5.0 and update for mapnik 3.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - 0.10
+  - "4"
+  - "6"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: node_js
+
 node_js:
-  - 0.10
+  - "0.10"
   - "4"
-  - "6"
+
+addons:
+  apt:
+    sources: [ 'ubuntu-toolchain-r-test' ]
+    packages: [ 'libstdc++-5-dev' ]
 
 sudo: false
 
-before_install:
-# install c++11 capable libstdc++ without sudo
-- if [[ $(uname -s) == 'Linux' ]]; then wget https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test/+files/libstdc%2B%2B6_4.8.1-2ubuntu1~12.04_amd64.deb && dpkg -x libstdc++6_4.8.1-2ubuntu1~12.04_amd64.deb ./ && export LD_PRELOAD=$(pwd)/usr/lib/x86_64-linux-gnu/libstdc++.so.6; fi
+install:
+- npm install
+
+script:
+- npm test
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.5.0
+
+* Updated version of blend to 1.3.0
+* Updated version of node-mapnik to 3.6.0
+
 # 1.4.0
 
 * Updated version of blend and mapnik

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs'),
     path = require('path'),
-    blend = require('blend'),
+    blend = require('@mapbox/blend'),
     xtend = require('xtend'),
     errcode = require('err-code');
     maki = require('maki');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/makizushi",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "professional maki chef",
   "main": "index.js",
   "directories": {
@@ -8,13 +8,13 @@
   },
   "dependencies": {
     "err-code": "0.1.2",
-    "blend": "~1.2.0",
+    "@mapbox/blend": "~1.3.0",
     "maki": "0.5.0",
     "xtend": "~3.0.0",
-    "mapnik": "~3.5.0"
+    "mapnik": "~3.6.0"
   },
   "devDependencies": {
-    "assert-http": "~1.0.1",
+    "@mapbox/assert-http": "~1.1.4",
     "tap": "~0.4.8"
   },
   "scripts": {

--- a/test/maki.js
+++ b/test/maki.js
@@ -1,7 +1,7 @@
 var test = require('tap').test,
     fs = require('fs'),
     pins = require('./pins.json'),
-    imageEquals = require('assert-http').imageEquals,
+    imageEquals = require('@mapbox/assert-http').imageEquals,
     makizushi = require('../');
 
 var REGEN = false;


### PR DESCRIPTION
/cc @springmeyer for review

Due to change in namespace after merge:

- [ ] Run `npm publish --access=public` to publish the first namespaced version
- [ ] Run `npm deprecate makizushi "This module has moved: please install @mapbox/makizushi instead"`