### PR TITLE
mapnik v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ install:
 
 script:
 - npm test
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - "0.10"
-  - "4"
+  - 6
+  - 8
 
 addons:
   apt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.0.0
+
+* Updated version of node-mapnik to 4.0.1
+* Ends node v0.10.x support
+
 # 2.0.0
 
 * Updated version of blend to 2.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/makizushi",
-  "version": "2.0.1-0",
+  "version": "2.0.1-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,1979 +5,25 @@
   "requires": true,
   "dependencies": {
     "@mapbox/assert-http": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/assert-http/-/assert-http-1.1.5.tgz",
-      "integrity": "sha1-cAwJOd7tpp4gv4Wkv1aAXvn8gFM=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/assert-http/-/assert-http-2.0.0.tgz",
+      "integrity": "sha1-fTkmMKlNAyYbe3Ko9Vk40HEFPEY=",
       "dev": true,
       "requires": {
         "assert-diff": "0.0.4",
-        "mapnik": "3.7.2",
-        "mkdirp": "0.3.5",
+        "mapnik": "3.x || 4.x",
+        "mkdirp": "0.3.x",
         "request": "2.78.0",
-        "sort-keys": "1.1.2",
-        "underscore": "1.4.4"
-      },
-      "dependencies": {
-        "mapnik": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-3.7.2.tgz",
-          "integrity": "sha512-mdpXpSds+Mi+1fABf2spMOQ+lnrJqE3isBMHDxCisZOPvppsTKAyGB9i8cXT+qbewcLgTcezgA8+SbeQQr/v9g==",
-          "dev": true,
-          "requires": {
-            "mapnik-vector-tile": "1.6.1",
-            "nan": "2.8.0",
-            "node-pre-gyp": "0.6.39",
-            "protozero": "1.5.1"
-          },
-          "dependencies": {
-            "node-pre-gyp": {
-              "version": "0.6.39",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "detect-libc": "1.0.3",
-                "hawk": "3.1.3",
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.2",
-                "rc": "1.2.6",
-                "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.5.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.1"
-              },
-              "dependencies": {
-                "detect-libc": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "dev": true
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "hoek": "2.16.3"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "boom": "2.10.1"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "hoek": "2.16.3"
-                      }
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "minimist": "0.0.8"
-                  },
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "abbrev": "1.1.1",
-                    "osenv": "0.1.5"
-                  },
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.1.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "osenv": {
-                      "version": "0.1.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
-                      },
-                      "dependencies": {
-                        "os-homedir": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "os-tmpdir": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "npmlog": {
-                  "version": "4.1.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "are-we-there-yet": "1.1.4",
-                    "console-control-strings": "1.1.0",
-                    "gauge": "2.7.4",
-                    "set-blocking": "2.0.0"
-                  },
-                  "dependencies": {
-                    "are-we-there-yet": {
-                      "version": "1.1.4",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
-                      },
-                      "dependencies": {
-                        "delegates": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "readable-stream": {
-                          "version": "2.3.6",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "core-util-is": "1.0.2",
-                            "inherits": "2.0.3",
-                            "isarray": "1.0.0",
-                            "process-nextick-args": "2.0.0",
-                            "safe-buffer": "5.1.1",
-                            "string_decoder": "1.1.1",
-                            "util-deprecate": "1.0.2"
-                          },
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "inherits": {
-                              "version": "2.0.3",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "isarray": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "process-nextick-args": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "safe-buffer": {
-                              "version": "5.1.1",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "string_decoder": {
-                              "version": "1.1.1",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "safe-buffer": "5.1.1"
-                              }
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "console-control-strings": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "gauge": {
-                      "version": "2.7.4",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
-                      },
-                      "dependencies": {
-                        "aproba": {
-                          "version": "1.2.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "has-unicode": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "object-assign": {
-                          "version": "4.1.1",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "string-width": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "code-point-at": "1.1.0",
-                            "is-fullwidth-code-point": "1.0.0",
-                            "strip-ansi": "3.0.1"
-                          },
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.1.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "number-is-nan": "1.0.1"
-                              },
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "ansi-regex": "2.1.1"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "wide-align": {
-                          "version": "1.1.2",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "string-width": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "set-blocking": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "rc": {
-                  "version": "1.2.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "deep-extend": "0.4.2",
-                    "ini": "1.3.5",
-                    "minimist": "1.2.0",
-                    "strip-json-comments": "2.0.1"
-                  },
-                  "dependencies": {
-                    "deep-extend": {
-                      "version": "0.4.2",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "ini": {
-                      "version": "1.3.5",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "minimist": {
-                      "version": "1.2.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "strip-json-comments": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "request": {
-                  "version": "2.81.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "aws-sign2": "0.6.0",
-                    "aws4": "1.7.0",
-                    "caseless": "0.12.0",
-                    "combined-stream": "1.0.6",
-                    "extend": "3.0.1",
-                    "forever-agent": "0.6.1",
-                    "form-data": "2.1.4",
-                    "har-validator": "4.2.1",
-                    "hawk": "3.1.3",
-                    "http-signature": "1.1.1",
-                    "is-typedarray": "1.0.0",
-                    "isstream": "0.1.2",
-                    "json-stringify-safe": "5.0.1",
-                    "mime-types": "2.1.18",
-                    "oauth-sign": "0.8.2",
-                    "performance-now": "0.2.0",
-                    "qs": "6.4.0",
-                    "safe-buffer": "5.1.1",
-                    "stringstream": "0.0.5",
-                    "tough-cookie": "2.3.4",
-                    "tunnel-agent": "0.6.0",
-                    "uuid": "3.2.1"
-                  },
-                  "dependencies": {
-                    "aws-sign2": {
-                      "version": "0.6.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "aws4": {
-                      "version": "1.7.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "caseless": {
-                      "version": "0.12.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "combined-stream": {
-                      "version": "1.0.6",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "delayed-stream": "1.0.0"
-                      },
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "extend": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "form-data": {
-                      "version": "2.1.4",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.6",
-                        "mime-types": "2.1.18"
-                      },
-                      "dependencies": {
-                        "asynckit": {
-                          "version": "0.4.0",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "har-validator": {
-                      "version": "4.2.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
-                      },
-                      "dependencies": {
-                        "ajv": {
-                          "version": "4.11.8",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "co": "4.6.0",
-                            "json-stable-stringify": "1.0.1"
-                          },
-                          "dependencies": {
-                            "co": {
-                              "version": "4.6.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "json-stable-stringify": {
-                              "version": "1.0.1",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "jsonify": "0.0.0"
-                              },
-                              "dependencies": {
-                                "jsonify": {
-                                  "version": "0.0.0",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "har-schema": {
-                          "version": "1.0.5",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "http-signature": {
-                      "version": "1.1.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.1"
-                      },
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.2.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "jsprim": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "assert-plus": "1.0.0",
-                            "extsprintf": "1.3.0",
-                            "json-schema": "0.2.3",
-                            "verror": "1.10.0"
-                          },
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "extsprintf": {
-                              "version": "1.3.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "json-schema": {
-                              "version": "0.2.3",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "verror": {
-                              "version": "1.10.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "assert-plus": "1.0.0",
-                                "core-util-is": "1.0.2",
-                                "extsprintf": "1.3.0"
-                              },
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "sshpk": {
-                          "version": "1.14.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "asn1": "0.2.3",
-                            "assert-plus": "1.0.0",
-                            "bcrypt-pbkdf": "1.0.1",
-                            "dashdash": "1.14.1",
-                            "ecc-jsbn": "0.1.1",
-                            "getpass": "0.1.7",
-                            "jsbn": "0.1.1",
-                            "tweetnacl": "0.14.5"
-                          },
-                          "dependencies": {
-                            "asn1": {
-                              "version": "0.2.3",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "assert-plus": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "bcrypt-pbkdf": {
-                              "version": "1.0.1",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "tweetnacl": "0.14.5"
-                              }
-                            },
-                            "dashdash": {
-                              "version": "1.14.1",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "assert-plus": "1.0.0"
-                              }
-                            },
-                            "ecc-jsbn": {
-                              "version": "0.1.1",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "jsbn": "0.1.1"
-                              }
-                            },
-                            "getpass": {
-                              "version": "0.1.7",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "assert-plus": "1.0.0"
-                              }
-                            },
-                            "jsbn": {
-                              "version": "0.1.1",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true
-                            },
-                            "tweetnacl": {
-                              "version": "0.14.5",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "mime-types": {
-                      "version": "2.1.18",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "mime-db": "1.33.0"
-                      },
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.33.0",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.2",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "performance-now": {
-                      "version": "0.2.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "qs": {
-                      "version": "6.4.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "stringstream": {
-                      "version": "0.0.5",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "tough-cookie": {
-                      "version": "2.3.4",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "punycode": "1.4.1"
-                      },
-                      "dependencies": {
-                        "punycode": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "tunnel-agent": {
-                      "version": "0.6.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "safe-buffer": "5.1.1"
-                      }
-                    },
-                    "uuid": {
-                      "version": "3.2.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.6.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "glob": "7.1.2"
-                  },
-                  "dependencies": {
-                    "glob": {
-                      "version": "7.1.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                      },
-                      "dependencies": {
-                        "fs.realpath": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "inflight": {
-                          "version": "1.0.6",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
-                          },
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "minimatch": {
-                          "version": "3.0.4",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "brace-expansion": "1.1.11"
-                          },
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.11",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "balanced-match": "1.0.0",
-                                "concat-map": "0.0.1"
-                              },
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "1.0.0",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "wrappy": "1.0.2"
-                          },
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "5.5.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "tar": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "block-stream": "0.0.9",
-                    "fstream": "1.0.11",
-                    "inherits": "2.0.3"
-                  },
-                  "dependencies": {
-                    "block-stream": {
-                      "version": "0.0.9",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "inherits": "2.0.3"
-                      }
-                    },
-                    "fstream": {
-                      "version": "1.0.11",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.11",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "tar-pack": {
-                  "version": "3.4.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "debug": "2.6.9",
-                    "fstream": "1.0.11",
-                    "fstream-ignore": "1.0.5",
-                    "once": "1.4.0",
-                    "readable-stream": "2.3.6",
-                    "rimraf": "2.6.2",
-                    "tar": "2.2.1",
-                    "uid-number": "0.0.6"
-                  },
-                  "dependencies": {
-                    "debug": {
-                      "version": "2.6.9",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "fstream": {
-                      "version": "1.0.11",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.11",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "fstream-ignore": {
-                      "version": "1.0.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
-                      },
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "minimatch": {
-                          "version": "3.0.4",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "brace-expansion": "1.1.11"
-                          },
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.11",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "balanced-match": "1.0.0",
-                                "concat-map": "0.0.1"
-                              },
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "1.0.0",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "2.3.6",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "process-nextick-args": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "safe-buffer": {
-                          "version": "5.1.1",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "string_decoder": {
-                          "version": "1.1.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "safe-buffer": "5.1.1"
-                          }
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "uid-number": {
-                      "version": "0.0.6",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "mapnik-vector-tile": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/mapnik-vector-tile/-/mapnik-vector-tile-1.6.1.tgz",
-          "integrity": "sha1-Pf8n1eTx/MZH1ljqislZEh8zn1k=",
-          "dev": true
-        },
-        "nan": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-          "dev": true
-        }
+        "sort-keys": "^1.1.2",
+        "underscore": "1.4.x"
       }
     },
     "@mapbox/blend": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/blend/-/blend-2.0.0.tgz",
-      "integrity": "sha1-cvJVQXgQ+o+cfyL1M76UQWYivy4=",
+      "version": "2.0.1-0",
+      "resolved": "https://registry.npmjs.org/@mapbox/blend/-/blend-2.0.1-0.tgz",
+      "integrity": "sha512-UdDB22GbA3qiaNegAWh3dMV6G88KroFqD5WIfwVtRSj8RLGGCz0iuThPLXAY13Mfe6HiyEyr8GxkwPuCYxswnA==",
       "requires": {
-        "mapnik": "3.7.2"
-      },
-      "dependencies": {
-        "mapnik": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-3.7.2.tgz",
-          "integrity": "sha512-mdpXpSds+Mi+1fABf2spMOQ+lnrJqE3isBMHDxCisZOPvppsTKAyGB9i8cXT+qbewcLgTcezgA8+SbeQQr/v9g==",
-          "requires": {
-            "mapnik-vector-tile": "1.6.1",
-            "nan": "2.8.0",
-            "node-pre-gyp": "0.6.39",
-            "protozero": "1.5.1"
-          },
-          "dependencies": {
-            "node-pre-gyp": {
-              "version": "0.6.39",
-              "bundled": true,
-              "requires": {
-                "detect-libc": "1.0.3",
-                "hawk": "3.1.3",
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.2",
-                "rc": "1.2.6",
-                "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.5.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.1"
-              },
-              "dependencies": {
-                "detect-libc": {
-                  "version": "1.0.3",
-                  "bundled": true
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "2.16.3"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "bundled": true,
-                      "requires": {
-                        "boom": "2.10.1"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "bundled": true
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "2.16.3"
-                      }
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "bundled": true,
-                  "requires": {
-                    "minimist": "0.0.8"
-                  },
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "bundled": true
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "abbrev": "1.1.1",
-                    "osenv": "0.1.5"
-                  },
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.1.1",
-                      "bundled": true
-                    },
-                    "osenv": {
-                      "version": "0.1.5",
-                      "bundled": true,
-                      "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
-                      },
-                      "dependencies": {
-                        "os-homedir": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        },
-                        "os-tmpdir": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "npmlog": {
-                  "version": "4.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "are-we-there-yet": "1.1.4",
-                    "console-control-strings": "1.1.0",
-                    "gauge": "2.7.4",
-                    "set-blocking": "2.0.0"
-                  },
-                  "dependencies": {
-                    "are-we-there-yet": {
-                      "version": "1.1.4",
-                      "bundled": true,
-                      "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
-                      },
-                      "dependencies": {
-                        "delegates": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "readable-stream": {
-                          "version": "2.3.6",
-                          "bundled": true,
-                          "requires": {
-                            "core-util-is": "1.0.2",
-                            "inherits": "2.0.3",
-                            "isarray": "1.0.0",
-                            "process-nextick-args": "2.0.0",
-                            "safe-buffer": "5.1.1",
-                            "string_decoder": "1.1.1",
-                            "util-deprecate": "1.0.2"
-                          },
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2",
-                              "bundled": true
-                            },
-                            "inherits": {
-                              "version": "2.0.3",
-                              "bundled": true
-                            },
-                            "isarray": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "process-nextick-args": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            },
-                            "safe-buffer": {
-                              "version": "5.1.1",
-                              "bundled": true
-                            },
-                            "string_decoder": {
-                              "version": "1.1.1",
-                              "bundled": true,
-                              "requires": {
-                                "safe-buffer": "5.1.1"
-                              }
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "console-control-strings": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "gauge": {
-                      "version": "2.7.4",
-                      "bundled": true,
-                      "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
-                      },
-                      "dependencies": {
-                        "aproba": {
-                          "version": "1.2.0",
-                          "bundled": true
-                        },
-                        "has-unicode": {
-                          "version": "2.0.1",
-                          "bundled": true
-                        },
-                        "object-assign": {
-                          "version": "4.1.1",
-                          "bundled": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true
-                        },
-                        "string-width": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "code-point-at": "1.1.0",
-                            "is-fullwidth-code-point": "1.0.0",
-                            "strip-ansi": "3.0.1"
-                          },
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.1.0",
-                              "bundled": true
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "number-is-nan": "1.0.1"
-                              },
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "ansi-regex": "2.1.1"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "wide-align": {
-                          "version": "1.1.2",
-                          "bundled": true,
-                          "requires": {
-                            "string-width": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "set-blocking": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "rc": {
-                  "version": "1.2.6",
-                  "bundled": true,
-                  "requires": {
-                    "deep-extend": "0.4.2",
-                    "ini": "1.3.5",
-                    "minimist": "1.2.0",
-                    "strip-json-comments": "2.0.1"
-                  },
-                  "dependencies": {
-                    "deep-extend": {
-                      "version": "0.4.2",
-                      "bundled": true
-                    },
-                    "ini": {
-                      "version": "1.3.5",
-                      "bundled": true
-                    },
-                    "minimist": {
-                      "version": "1.2.0",
-                      "bundled": true
-                    },
-                    "strip-json-comments": {
-                      "version": "2.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "request": {
-                  "version": "2.81.0",
-                  "bundled": true,
-                  "requires": {
-                    "aws-sign2": "0.6.0",
-                    "aws4": "1.7.0",
-                    "caseless": "0.12.0",
-                    "combined-stream": "1.0.6",
-                    "extend": "3.0.1",
-                    "forever-agent": "0.6.1",
-                    "form-data": "2.1.4",
-                    "har-validator": "4.2.1",
-                    "hawk": "3.1.3",
-                    "http-signature": "1.1.1",
-                    "is-typedarray": "1.0.0",
-                    "isstream": "0.1.2",
-                    "json-stringify-safe": "5.0.1",
-                    "mime-types": "2.1.18",
-                    "oauth-sign": "0.8.2",
-                    "performance-now": "0.2.0",
-                    "qs": "6.4.0",
-                    "safe-buffer": "5.1.1",
-                    "stringstream": "0.0.5",
-                    "tough-cookie": "2.3.4",
-                    "tunnel-agent": "0.6.0",
-                    "uuid": "3.2.1"
-                  },
-                  "dependencies": {
-                    "aws-sign2": {
-                      "version": "0.6.0",
-                      "bundled": true
-                    },
-                    "aws4": {
-                      "version": "1.7.0",
-                      "bundled": true
-                    },
-                    "caseless": {
-                      "version": "0.12.0",
-                      "bundled": true
-                    },
-                    "combined-stream": {
-                      "version": "1.0.6",
-                      "bundled": true,
-                      "requires": {
-                        "delayed-stream": "1.0.0"
-                      },
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "extend": {
-                      "version": "3.0.1",
-                      "bundled": true
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "bundled": true
-                    },
-                    "form-data": {
-                      "version": "2.1.4",
-                      "bundled": true,
-                      "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.6",
-                        "mime-types": "2.1.18"
-                      },
-                      "dependencies": {
-                        "asynckit": {
-                          "version": "0.4.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "har-validator": {
-                      "version": "4.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
-                      },
-                      "dependencies": {
-                        "ajv": {
-                          "version": "4.11.8",
-                          "bundled": true,
-                          "requires": {
-                            "co": "4.6.0",
-                            "json-stable-stringify": "1.0.1"
-                          },
-                          "dependencies": {
-                            "co": {
-                              "version": "4.6.0",
-                              "bundled": true
-                            },
-                            "json-stable-stringify": {
-                              "version": "1.0.1",
-                              "bundled": true,
-                              "requires": {
-                                "jsonify": "0.0.0"
-                              },
-                              "dependencies": {
-                                "jsonify": {
-                                  "version": "0.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "har-schema": {
-                          "version": "1.0.5",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "http-signature": {
-                      "version": "1.1.1",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.1"
-                      },
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.2.0",
-                          "bundled": true
-                        },
-                        "jsprim": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "assert-plus": "1.0.0",
-                            "extsprintf": "1.3.0",
-                            "json-schema": "0.2.3",
-                            "verror": "1.10.0"
-                          },
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "extsprintf": {
-                              "version": "1.3.0",
-                              "bundled": true
-                            },
-                            "json-schema": {
-                              "version": "0.2.3",
-                              "bundled": true
-                            },
-                            "verror": {
-                              "version": "1.10.0",
-                              "bundled": true,
-                              "requires": {
-                                "assert-plus": "1.0.0",
-                                "core-util-is": "1.0.2",
-                                "extsprintf": "1.3.0"
-                              },
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "sshpk": {
-                          "version": "1.14.1",
-                          "bundled": true,
-                          "requires": {
-                            "asn1": "0.2.3",
-                            "assert-plus": "1.0.0",
-                            "bcrypt-pbkdf": "1.0.1",
-                            "dashdash": "1.14.1",
-                            "ecc-jsbn": "0.1.1",
-                            "getpass": "0.1.7",
-                            "jsbn": "0.1.1",
-                            "tweetnacl": "0.14.5"
-                          },
-                          "dependencies": {
-                            "asn1": {
-                              "version": "0.2.3",
-                              "bundled": true
-                            },
-                            "assert-plus": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "bcrypt-pbkdf": {
-                              "version": "1.0.1",
-                              "bundled": true,
-                              "optional": true,
-                              "requires": {
-                                "tweetnacl": "0.14.5"
-                              }
-                            },
-                            "dashdash": {
-                              "version": "1.14.1",
-                              "bundled": true,
-                              "requires": {
-                                "assert-plus": "1.0.0"
-                              }
-                            },
-                            "ecc-jsbn": {
-                              "version": "0.1.1",
-                              "bundled": true,
-                              "optional": true,
-                              "requires": {
-                                "jsbn": "0.1.1"
-                              }
-                            },
-                            "getpass": {
-                              "version": "0.1.7",
-                              "bundled": true,
-                              "requires": {
-                                "assert-plus": "1.0.0"
-                              }
-                            },
-                            "jsbn": {
-                              "version": "0.1.1",
-                              "bundled": true,
-                              "optional": true
-                            },
-                            "tweetnacl": {
-                              "version": "0.14.5",
-                              "bundled": true,
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "bundled": true
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "bundled": true
-                    },
-                    "mime-types": {
-                      "version": "2.1.18",
-                      "bundled": true,
-                      "requires": {
-                        "mime-db": "1.33.0"
-                      },
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.33.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.2",
-                      "bundled": true
-                    },
-                    "performance-now": {
-                      "version": "0.2.0",
-                      "bundled": true
-                    },
-                    "qs": {
-                      "version": "6.4.0",
-                      "bundled": true
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "bundled": true
-                    },
-                    "stringstream": {
-                      "version": "0.0.5",
-                      "bundled": true
-                    },
-                    "tough-cookie": {
-                      "version": "2.3.4",
-                      "bundled": true,
-                      "requires": {
-                        "punycode": "1.4.1"
-                      },
-                      "dependencies": {
-                        "punycode": {
-                          "version": "1.4.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "tunnel-agent": {
-                      "version": "0.6.0",
-                      "bundled": true,
-                      "requires": {
-                        "safe-buffer": "5.1.1"
-                      }
-                    },
-                    "uuid": {
-                      "version": "3.2.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.6.2",
-                  "bundled": true,
-                  "requires": {
-                    "glob": "7.1.2"
-                  },
-                  "dependencies": {
-                    "glob": {
-                      "version": "7.1.2",
-                      "bundled": true,
-                      "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                      },
-                      "dependencies": {
-                        "fs.realpath": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "inflight": {
-                          "version": "1.0.6",
-                          "bundled": true,
-                          "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
-                          },
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "bundled": true
-                        },
-                        "minimatch": {
-                          "version": "3.0.4",
-                          "bundled": true,
-                          "requires": {
-                            "brace-expansion": "1.1.11"
-                          },
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.11",
-                              "bundled": true,
-                              "requires": {
-                                "balanced-match": "1.0.0",
-                                "concat-map": "0.0.1"
-                              },
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "wrappy": "1.0.2"
-                          },
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "5.5.0",
-                  "bundled": true
-                },
-                "tar": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "block-stream": "0.0.9",
-                    "fstream": "1.0.11",
-                    "inherits": "2.0.3"
-                  },
-                  "dependencies": {
-                    "block-stream": {
-                      "version": "0.0.9",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3"
-                      }
-                    },
-                    "fstream": {
-                      "version": "1.0.11",
-                      "bundled": true,
-                      "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.11",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "bundled": true
-                    }
-                  }
-                },
-                "tar-pack": {
-                  "version": "3.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "debug": "2.6.9",
-                    "fstream": "1.0.11",
-                    "fstream-ignore": "1.0.5",
-                    "once": "1.4.0",
-                    "readable-stream": "2.3.6",
-                    "rimraf": "2.6.2",
-                    "tar": "2.2.1",
-                    "uid-number": "0.0.6"
-                  },
-                  "dependencies": {
-                    "debug": {
-                      "version": "2.6.9",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "fstream": {
-                      "version": "1.0.11",
-                      "bundled": true,
-                      "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.11",
-                          "bundled": true
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "fstream-ignore": {
-                      "version": "1.0.5",
-                      "bundled": true,
-                      "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
-                      },
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.3",
-                          "bundled": true
-                        },
-                        "minimatch": {
-                          "version": "3.0.4",
-                          "bundled": true,
-                          "requires": {
-                            "brace-expansion": "1.1.11"
-                          },
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.11",
-                              "bundled": true,
-                              "requires": {
-                                "balanced-match": "1.0.0",
-                                "concat-map": "0.0.1"
-                              },
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "2.3.6",
-                      "bundled": true,
-                      "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "bundled": true
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "process-nextick-args": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        },
-                        "safe-buffer": {
-                          "version": "5.1.1",
-                          "bundled": true
-                        },
-                        "string_decoder": {
-                          "version": "1.1.1",
-                          "bundled": true,
-                          "requires": {
-                            "safe-buffer": "5.1.1"
-                          }
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "uid-number": {
-                      "version": "0.0.6",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "mapnik-vector-tile": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/mapnik-vector-tile/-/mapnik-vector-tile-1.6.1.tgz",
-          "integrity": "sha1-Pf8n1eTx/MZH1ljqislZEh8zn1k="
-        },
-        "nan": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
-        }
+        "mapnik": "^4.0.1"
       }
     },
     "abbrev": {
@@ -2006,8 +52,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "asn1": {
@@ -2016,7 +62,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-diff": {
@@ -2065,7 +111,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "boom": {
@@ -2074,7 +120,7 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
@@ -2082,7 +128,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2098,7 +144,7 @@
       "integrity": "sha1-yImSRkqOKm7ehpMDdfkrWAd++Xw=",
       "dev": true,
       "requires": {
-        "burrito": "0.2.12"
+        "burrito": ">=0.2.5 <0.3"
       }
     },
     "burrito": {
@@ -2107,8 +153,8 @@
       "integrity": "sha1-0NbmrIHV6ZeJxvpKzLCwAx6lT2s=",
       "dev": true,
       "requires": {
-        "traverse": "0.5.2",
-        "uglify-js": "1.1.1"
+        "traverse": "~0.5.1",
+        "uglify-js": "~1.1.1"
       },
       "dependencies": {
         "traverse": {
@@ -2131,11 +177,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "charm": {
@@ -2155,7 +201,7 @@
       "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.8.2"
+        "es5-ext": "0.8.x"
       }
     },
     "code-point-at": {
@@ -2169,7 +215,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -2199,7 +245,7 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "dashdash": {
@@ -2208,7 +254,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2266,9 +312,9 @@
       "integrity": "sha1-qyOzH1ZJtvqo49KsvTNEZzZcpvo=",
       "dev": true,
       "requires": {
-        "charm": "0.1.2",
-        "deep-is": "0.1.3",
-        "traverse": "0.6.6"
+        "charm": "0.1.x",
+        "deep-is": "0.1.x",
+        "traverse": "0.6.x"
       }
     },
     "difflib": {
@@ -2277,7 +323,7 @@
       "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
       "dev": true,
       "requires": {
-        "heap": "0.2.6"
+        "heap": ">= 0.2.0"
       }
     },
     "dreamopt": {
@@ -2286,7 +332,7 @@
       "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
       "dev": true,
       "requires": {
-        "wordwrap": "1.0.0"
+        "wordwrap": ">=0.0.2"
       }
     },
     "ecc-jsbn": {
@@ -2296,8 +342,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "err-code": {
@@ -2341,9 +387,9 @@
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.7",
-        "mime-types": "2.1.20"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fs-minipass": {
@@ -2351,7 +397,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "minipass": "2.3.4"
+        "minipass": "^2.2.1"
       }
     },
     "fs.realpath": {
@@ -2364,14 +410,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "generate-function": {
@@ -2380,7 +426,7 @@
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.2"
       }
     },
     "generate-object-property": {
@@ -2389,7 +435,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "getpass": {
@@ -2398,7 +444,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2415,8 +461,8 @@
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimatch": "0.3.0"
+        "inherits": "2",
+        "minimatch": "0.3"
       }
     },
     "har-validator": {
@@ -2425,10 +471,10 @@
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.18.0",
-        "is-my-json-valid": "2.19.0",
-        "pinkie-promise": "2.0.1"
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -2437,7 +483,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-unicode": {
@@ -2451,10 +497,10 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "heap": {
@@ -2475,9 +521,9 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2493,7 +539,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore-walk": {
@@ -2501,7 +547,7 @@
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -2509,7 +555,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -2519,8 +565,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2538,7 +584,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-my-ip-valid": {
@@ -2553,11 +599,11 @@
       "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "requires": {
-        "generate-function": "2.3.1",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "xtend": {
@@ -2610,9 +656,9 @@
       "integrity": "sha1-bbw64tJeB1p/1xvNmHRFhmb7aBs=",
       "dev": true,
       "requires": {
-        "cli-color": "0.1.7",
-        "difflib": "0.2.4",
-        "dreamopt": "0.6.0"
+        "cli-color": "~0.1.6",
+        "difflib": "~0.2.1",
+        "dreamopt": "~0.6.0"
       }
     },
     "json-schema": {
@@ -2670,8 +716,8 @@
       "integrity": "sha512-iVlsplv9fAJG6E3+hAUT5eNDZ5ZuEr4+Libc70C8On+Sh381rnbh56Q5dxO89DQw6Zhd4sKD5QtIxtyncWddjA==",
       "requires": {
         "mapnik-vector-tile": "2.2.1",
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.3"
+        "nan": "~2.10.0",
+        "node-pre-gyp": "~0.10.0"
       }
     },
     "mapnik-vector-tile": {
@@ -2691,7 +737,7 @@
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "~1.36.0"
       }
     },
     "minimatch": {
@@ -2700,8 +746,8 @@
       "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
     },
     "minimist": {
@@ -2714,8 +760,8 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
       "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
       "requires": {
-        "safe-buffer": "5.1.2",
-        "yallist": "3.0.2"
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
       }
     },
     "minizlib": {
@@ -2723,7 +769,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "requires": {
-        "minipass": "2.3.4"
+        "minipass": "^2.2.1"
       }
     },
     "mkdirp": {
@@ -2747,9 +793,9 @@
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.3.tgz",
       "integrity": "sha512-GPL22d/U9cai87FcCPO6e+MT3vyHS2j+zwotakDc7kE2DtUAqFKMXLJCTtRp+5S75vXIwQPvIxkvlctxf9q4gQ==",
       "requires": {
-        "debug": "2.6.9",
-        "iconv-lite": "0.4.24",
-        "sax": "1.2.4"
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
       }
     },
     "node-pre-gyp": {
@@ -2757,16 +803,16 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
       "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
       "requires": {
-        "detect-libc": "1.0.3",
-        "mkdirp": "0.5.1",
-        "needle": "2.2.3",
-        "nopt": "4.0.1",
-        "npm-packlist": "1.1.11",
-        "npmlog": "4.1.2",
-        "rc": "1.2.8",
-        "rimraf": "2.6.2",
-        "semver": "5.5.1",
-        "tar": "4.4.6"
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
       },
       "dependencies": {
         "mkdirp": {
@@ -2782,8 +828,8 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         }
       }
@@ -2800,7 +846,7 @@
       "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "npm-bundled": {
@@ -2813,8 +859,8 @@
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.11.tgz",
       "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
       "requires": {
-        "ignore-walk": "3.0.1",
-        "npm-bundled": "1.0.5"
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
       }
     },
     "npmlog": {
@@ -2822,10 +868,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -2849,7 +895,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "os-homedir": {
@@ -2867,8 +913,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "path-is-absolute": {
@@ -2888,18 +934,13 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-    },
-    "protozero": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/protozero/-/protozero-1.5.1.tgz",
-      "integrity": "sha1-Wiffb7bh7XQ/UQgSrnbAgvWxZjg="
     },
     "punycode": {
       "version": "1.4.1",
@@ -2918,10 +959,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -2936,13 +977,13 @@
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "request": {
@@ -2951,26 +992,26 @@
       "integrity": "sha1-4cjew0bhyBkjskrNszfxHeyr6cw=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.8.0",
-        "caseless": "0.11.0",
-        "combined-stream": "1.0.7",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.20",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.8.2",
-        "qs": "6.3.2",
-        "stringstream": "0.0.6",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.4.3"
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~2.0.6",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "node-uuid": "~1.4.7",
+        "oauth-sign": "~0.8.1",
+        "qs": "~6.3.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "~0.4.1"
       }
     },
     "rimraf": {
@@ -2978,7 +1019,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "glob": {
@@ -2986,12 +1027,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -2999,7 +1040,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -3010,7 +1051,7 @@
       "integrity": "sha1-NE8FfY1F0zrrxsyCIEZ49pxIV8w=",
       "dev": true,
       "requires": {
-        "bunker": "0.1.2"
+        "bunker": "0.1.X"
       }
     },
     "safe-buffer": {
@@ -3061,7 +1102,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "sort-keys": {
@@ -3070,7 +1111,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "sshpk": {
@@ -3079,15 +1120,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -3103,9 +1144,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -3113,7 +1154,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -3127,7 +1168,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-json-comments": {
@@ -3147,16 +1188,16 @@
       "integrity": "sha1-OYYTTWdZcn/CIj5hEm7rhyQ6zLw=",
       "dev": true,
       "requires": {
-        "buffer-equal": "0.0.2",
-        "deep-equal": "0.0.0",
-        "difflet": "0.2.6",
-        "glob": "3.2.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.3.5",
-        "nopt": "2.2.1",
-        "runforcover": "0.0.2",
-        "slide": "1.1.6",
-        "yamlish": "0.0.7"
+        "buffer-equal": "~0.0.0",
+        "deep-equal": "~0.0.0",
+        "difflet": "~0.2.0",
+        "glob": "~3.2.1",
+        "inherits": "*",
+        "mkdirp": "~0.3 || 0.4 || 0.5",
+        "nopt": "~2",
+        "runforcover": "~0.0.2",
+        "slide": "*",
+        "yamlish": "*"
       }
     },
     "tar": {
@@ -3164,13 +1205,13 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
       "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
       "requires": {
-        "chownr": "1.1.1",
-        "fs-minipass": "1.2.5",
-        "minipass": "2.3.4",
-        "minizlib": "1.1.0",
-        "mkdirp": "0.5.1",
-        "safe-buffer": "5.1.2",
-        "yallist": "3.0.2"
+        "chownr": "^1.0.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.3",
+        "minizlib": "^1.1.0",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
       },
       "dependencies": {
         "mkdirp": {
@@ -3189,7 +1230,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "traverse": {
@@ -3234,9 +1275,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -3252,7 +1293,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "wordwrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3286 @@
+{
+  "name": "@mapbox/makizushi",
+  "version": "2.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@mapbox/assert-http": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/assert-http/-/assert-http-1.1.5.tgz",
+      "integrity": "sha1-cAwJOd7tpp4gv4Wkv1aAXvn8gFM=",
+      "dev": true,
+      "requires": {
+        "assert-diff": "0.0.4",
+        "mapnik": "3.7.2",
+        "mkdirp": "0.3.5",
+        "request": "2.78.0",
+        "sort-keys": "1.1.2",
+        "underscore": "1.4.4"
+      },
+      "dependencies": {
+        "mapnik": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-3.7.2.tgz",
+          "integrity": "sha512-mdpXpSds+Mi+1fABf2spMOQ+lnrJqE3isBMHDxCisZOPvppsTKAyGB9i8cXT+qbewcLgTcezgA8+SbeQQr/v9g==",
+          "dev": true,
+          "requires": {
+            "mapnik-vector-tile": "1.6.1",
+            "nan": "2.8.0",
+            "node-pre-gyp": "0.6.39",
+            "protozero": "1.5.1"
+          },
+          "dependencies": {
+            "node-pre-gyp": {
+              "version": "0.6.39",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "detect-libc": "1.0.3",
+                "hawk": "3.1.3",
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.2",
+                "rc": "1.2.6",
+                "request": "2.81.0",
+                "rimraf": "2.6.2",
+                "semver": "5.5.0",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.1"
+              },
+              "dependencies": {
+                "detect-libc": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "dev": true
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "abbrev": "1.1.1",
+                    "osenv": "0.1.5"
+                  },
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "osenv": {
+                      "version": "0.1.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                      },
+                      "dependencies": {
+                        "os-homedir": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "os-tmpdir": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "are-we-there-yet": "1.1.4",
+                    "console-control-strings": "1.1.0",
+                    "gauge": "2.7.4",
+                    "set-blocking": "2.0.0"
+                  },
+                  "dependencies": {
+                    "are-we-there-yet": {
+                      "version": "1.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
+                      },
+                      "dependencies": {
+                        "delegates": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "readable-stream": {
+                          "version": "2.3.6",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "core-util-is": "1.0.2",
+                            "inherits": "2.0.3",
+                            "isarray": "1.0.0",
+                            "process-nextick-args": "2.0.0",
+                            "safe-buffer": "5.1.1",
+                            "string_decoder": "1.1.1",
+                            "util-deprecate": "1.0.2"
+                          },
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "isarray": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "process-nextick-args": {
+                              "version": "2.0.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "safe-buffer": {
+                              "version": "5.1.1",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "string_decoder": {
+                              "version": "1.1.1",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "safe-buffer": "5.1.1"
+                              }
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "console-control-strings": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "gauge": {
+                      "version": "2.7.4",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                      },
+                      "dependencies": {
+                        "aproba": {
+                          "version": "1.2.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "has-unicode": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "object-assign": {
+                          "version": "4.1.1",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.1.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "number-is-nan": "1.0.1"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "wide-align": {
+                          "version": "1.1.2",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "string-width": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "set-blocking": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "1.2.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "deep-extend": "0.4.2",
+                    "ini": "1.3.5",
+                    "minimist": "1.2.0",
+                    "strip-json-comments": "2.0.1"
+                  },
+                  "dependencies": {
+                    "deep-extend": {
+                      "version": "0.4.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "ini": {
+                      "version": "1.3.5",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "strip-json-comments": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "aws-sign2": "0.6.0",
+                    "aws4": "1.7.0",
+                    "caseless": "0.12.0",
+                    "combined-stream": "1.0.6",
+                    "extend": "3.0.1",
+                    "forever-agent": "0.6.1",
+                    "form-data": "2.1.4",
+                    "har-validator": "4.2.1",
+                    "hawk": "3.1.3",
+                    "http-signature": "1.1.1",
+                    "is-typedarray": "1.0.0",
+                    "isstream": "0.1.2",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "2.1.18",
+                    "oauth-sign": "0.8.2",
+                    "performance-now": "0.2.0",
+                    "qs": "6.4.0",
+                    "safe-buffer": "5.1.1",
+                    "stringstream": "0.0.5",
+                    "tough-cookie": "2.3.4",
+                    "tunnel-agent": "0.6.0",
+                    "uuid": "3.2.1"
+                  },
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "aws4": {
+                      "version": "1.7.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "caseless": {
+                      "version": "0.12.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "combined-stream": {
+                      "version": "1.0.6",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "delayed-stream": "1.0.0"
+                      },
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "extend": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "form-data": {
+                      "version": "2.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "2.1.18"
+                      },
+                      "dependencies": {
+                        "asynckit": {
+                          "version": "0.4.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "har-validator": {
+                      "version": "4.2.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                      },
+                      "dependencies": {
+                        "ajv": {
+                          "version": "4.11.8",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "co": "4.6.0",
+                            "json-stable-stringify": "1.0.1"
+                          },
+                          "dependencies": {
+                            "co": {
+                              "version": "4.6.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "json-stable-stringify": {
+                              "version": "1.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "jsonify": "0.0.0"
+                              },
+                              "dependencies": {
+                                "jsonify": {
+                                  "version": "0.0.0",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "har-schema": {
+                          "version": "1.0.5",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.14.1"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "jsprim": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "assert-plus": "1.0.0",
+                            "extsprintf": "1.3.0",
+                            "json-schema": "0.2.3",
+                            "verror": "1.10.0"
+                          },
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "extsprintf": {
+                              "version": "1.3.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "json-schema": {
+                              "version": "0.2.3",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "verror": {
+                              "version": "1.10.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "assert-plus": "1.0.0",
+                                "core-util-is": "1.0.2",
+                                "extsprintf": "1.3.0"
+                              },
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "sshpk": {
+                          "version": "1.14.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "asn1": "0.2.3",
+                            "assert-plus": "1.0.0",
+                            "bcrypt-pbkdf": "1.0.1",
+                            "dashdash": "1.14.1",
+                            "ecc-jsbn": "0.1.1",
+                            "getpass": "0.1.7",
+                            "jsbn": "0.1.1",
+                            "tweetnacl": "0.14.5"
+                          },
+                          "dependencies": {
+                            "asn1": {
+                              "version": "0.2.3",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "bcrypt-pbkdf": {
+                              "version": "1.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "tweetnacl": "0.14.5"
+                              }
+                            },
+                            "dashdash": {
+                              "version": "1.14.1",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "assert-plus": "1.0.0"
+                              }
+                            },
+                            "ecc-jsbn": {
+                              "version": "0.1.1",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "jsbn": "0.1.1"
+                              }
+                            },
+                            "getpass": {
+                              "version": "0.1.7",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "assert-plus": "1.0.0"
+                              }
+                            },
+                            "jsbn": {
+                              "version": "0.1.1",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "tweetnacl": {
+                              "version": "0.14.5",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "mime-types": {
+                      "version": "2.1.18",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "mime-db": "1.33.0"
+                      },
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.33.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "performance-now": {
+                      "version": "0.2.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "qs": {
+                      "version": "6.4.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "tough-cookie": {
+                      "version": "2.3.4",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "punycode": "1.4.1"
+                      },
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.6.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "safe-buffer": "5.1.1"
+                      }
+                    },
+                    "uuid": {
+                      "version": "3.2.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "glob": "7.1.2"
+                  },
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.1.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                      },
+                      "dependencies": {
+                        "fs.realpath": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "inflight": {
+                          "version": "1.0.6",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "once": "1.4.0",
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "minimatch": {
+                          "version": "3.0.4",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "brace-expansion": "1.1.11"
+                          },
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.11",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "balanced-match": "1.0.0",
+                                "concat-map": "0.0.1"
+                              },
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "1.0.0",
+                                  "bundled": true,
+                                  "dev": true
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "5.5.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "block-stream": "0.0.9",
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3"
+                  },
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.9",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "inherits": "2.0.3"
+                      }
+                    },
+                    "fstream": {
+                      "version": "1.0.11",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.11",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "tar-pack": {
+                  "version": "3.4.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "debug": "2.6.9",
+                    "fstream": "1.0.11",
+                    "fstream-ignore": "1.0.5",
+                    "once": "1.4.0",
+                    "readable-stream": "2.3.6",
+                    "rimraf": "2.6.2",
+                    "tar": "2.2.1",
+                    "uid-number": "0.0.6"
+                  },
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.6.9",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "fstream": {
+                      "version": "1.0.11",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.11",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                      },
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "minimatch": {
+                          "version": "3.0.4",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "brace-expansion": "1.1.11"
+                          },
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.11",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "balanced-match": "1.0.0",
+                                "concat-map": "0.0.1"
+                              },
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "1.0.0",
+                                  "bundled": true,
+                                  "dev": true
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.3.6",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "process-nextick-args": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "safe-buffer": {
+                          "version": "5.1.1",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "1.1.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "safe-buffer": "5.1.1"
+                          }
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "mapnik-vector-tile": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/mapnik-vector-tile/-/mapnik-vector-tile-1.6.1.tgz",
+          "integrity": "sha1-Pf8n1eTx/MZH1ljqislZEh8zn1k=",
+          "dev": true
+        },
+        "nan": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+          "dev": true
+        }
+      }
+    },
+    "@mapbox/blend": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/blend/-/blend-2.0.0.tgz",
+      "integrity": "sha1-cvJVQXgQ+o+cfyL1M76UQWYivy4=",
+      "requires": {
+        "mapnik": "3.7.2"
+      },
+      "dependencies": {
+        "mapnik": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-3.7.2.tgz",
+          "integrity": "sha512-mdpXpSds+Mi+1fABf2spMOQ+lnrJqE3isBMHDxCisZOPvppsTKAyGB9i8cXT+qbewcLgTcezgA8+SbeQQr/v9g==",
+          "requires": {
+            "mapnik-vector-tile": "1.6.1",
+            "nan": "2.8.0",
+            "node-pre-gyp": "0.6.39",
+            "protozero": "1.5.1"
+          },
+          "dependencies": {
+            "node-pre-gyp": {
+              "version": "0.6.39",
+              "bundled": true,
+              "requires": {
+                "detect-libc": "1.0.3",
+                "hawk": "3.1.3",
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.2",
+                "rc": "1.2.6",
+                "request": "2.81.0",
+                "rimraf": "2.6.2",
+                "semver": "5.5.0",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.1"
+              },
+              "dependencies": {
+                "detect-libc": {
+                  "version": "1.0.3",
+                  "bundled": true
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "bundled": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "bundled": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "bundled": true
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "abbrev": "1.1.1",
+                    "osenv": "0.1.5"
+                  },
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.1.1",
+                      "bundled": true
+                    },
+                    "osenv": {
+                      "version": "0.1.5",
+                      "bundled": true,
+                      "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                      },
+                      "dependencies": {
+                        "os-homedir": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        },
+                        "os-tmpdir": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "are-we-there-yet": "1.1.4",
+                    "console-control-strings": "1.1.0",
+                    "gauge": "2.7.4",
+                    "set-blocking": "2.0.0"
+                  },
+                  "dependencies": {
+                    "are-we-there-yet": {
+                      "version": "1.1.4",
+                      "bundled": true,
+                      "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
+                      },
+                      "dependencies": {
+                        "delegates": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "readable-stream": {
+                          "version": "2.3.6",
+                          "bundled": true,
+                          "requires": {
+                            "core-util-is": "1.0.2",
+                            "inherits": "2.0.3",
+                            "isarray": "1.0.0",
+                            "process-nextick-args": "2.0.0",
+                            "safe-buffer": "5.1.1",
+                            "string_decoder": "1.1.1",
+                            "util-deprecate": "1.0.2"
+                          },
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "bundled": true
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "bundled": true
+                            },
+                            "isarray": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "process-nextick-args": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            },
+                            "safe-buffer": {
+                              "version": "5.1.1",
+                              "bundled": true
+                            },
+                            "string_decoder": {
+                              "version": "1.1.1",
+                              "bundled": true,
+                              "requires": {
+                                "safe-buffer": "5.1.1"
+                              }
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "console-control-strings": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "gauge": {
+                      "version": "2.7.4",
+                      "bundled": true,
+                      "requires": {
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                      },
+                      "dependencies": {
+                        "aproba": {
+                          "version": "1.2.0",
+                          "bundled": true
+                        },
+                        "has-unicode": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "object-assign": {
+                          "version": "4.1.1",
+                          "bundled": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true
+                        },
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "number-is-nan": "1.0.1"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "wide-align": {
+                          "version": "1.1.2",
+                          "bundled": true,
+                          "requires": {
+                            "string-width": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "set-blocking": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "1.2.6",
+                  "bundled": true,
+                  "requires": {
+                    "deep-extend": "0.4.2",
+                    "ini": "1.3.5",
+                    "minimist": "1.2.0",
+                    "strip-json-comments": "2.0.1"
+                  },
+                  "dependencies": {
+                    "deep-extend": {
+                      "version": "0.4.2",
+                      "bundled": true
+                    },
+                    "ini": {
+                      "version": "1.3.5",
+                      "bundled": true
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true
+                    },
+                    "strip-json-comments": {
+                      "version": "2.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "bundled": true,
+                  "requires": {
+                    "aws-sign2": "0.6.0",
+                    "aws4": "1.7.0",
+                    "caseless": "0.12.0",
+                    "combined-stream": "1.0.6",
+                    "extend": "3.0.1",
+                    "forever-agent": "0.6.1",
+                    "form-data": "2.1.4",
+                    "har-validator": "4.2.1",
+                    "hawk": "3.1.3",
+                    "http-signature": "1.1.1",
+                    "is-typedarray": "1.0.0",
+                    "isstream": "0.1.2",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "2.1.18",
+                    "oauth-sign": "0.8.2",
+                    "performance-now": "0.2.0",
+                    "qs": "6.4.0",
+                    "safe-buffer": "5.1.1",
+                    "stringstream": "0.0.5",
+                    "tough-cookie": "2.3.4",
+                    "tunnel-agent": "0.6.0",
+                    "uuid": "3.2.1"
+                  },
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "bundled": true
+                    },
+                    "aws4": {
+                      "version": "1.7.0",
+                      "bundled": true
+                    },
+                    "caseless": {
+                      "version": "0.12.0",
+                      "bundled": true
+                    },
+                    "combined-stream": {
+                      "version": "1.0.6",
+                      "bundled": true,
+                      "requires": {
+                        "delayed-stream": "1.0.0"
+                      },
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "extend": {
+                      "version": "3.0.1",
+                      "bundled": true
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "bundled": true
+                    },
+                    "form-data": {
+                      "version": "2.1.4",
+                      "bundled": true,
+                      "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "2.1.18"
+                      },
+                      "dependencies": {
+                        "asynckit": {
+                          "version": "0.4.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "har-validator": {
+                      "version": "4.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                      },
+                      "dependencies": {
+                        "ajv": {
+                          "version": "4.11.8",
+                          "bundled": true,
+                          "requires": {
+                            "co": "4.6.0",
+                            "json-stable-stringify": "1.0.1"
+                          },
+                          "dependencies": {
+                            "co": {
+                              "version": "4.6.0",
+                              "bundled": true
+                            },
+                            "json-stable-stringify": {
+                              "version": "1.0.1",
+                              "bundled": true,
+                              "requires": {
+                                "jsonify": "0.0.0"
+                              },
+                              "dependencies": {
+                                "jsonify": {
+                                  "version": "0.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "har-schema": {
+                          "version": "1.0.5",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.14.1"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "bundled": true
+                        },
+                        "jsprim": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0",
+                            "extsprintf": "1.3.0",
+                            "json-schema": "0.2.3",
+                            "verror": "1.10.0"
+                          },
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "extsprintf": {
+                              "version": "1.3.0",
+                              "bundled": true
+                            },
+                            "json-schema": {
+                              "version": "0.2.3",
+                              "bundled": true
+                            },
+                            "verror": {
+                              "version": "1.10.0",
+                              "bundled": true,
+                              "requires": {
+                                "assert-plus": "1.0.0",
+                                "core-util-is": "1.0.2",
+                                "extsprintf": "1.3.0"
+                              },
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "sshpk": {
+                          "version": "1.14.1",
+                          "bundled": true,
+                          "requires": {
+                            "asn1": "0.2.3",
+                            "assert-plus": "1.0.0",
+                            "bcrypt-pbkdf": "1.0.1",
+                            "dashdash": "1.14.1",
+                            "ecc-jsbn": "0.1.1",
+                            "getpass": "0.1.7",
+                            "jsbn": "0.1.1",
+                            "tweetnacl": "0.14.5"
+                          },
+                          "dependencies": {
+                            "asn1": {
+                              "version": "0.2.3",
+                              "bundled": true
+                            },
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "bcrypt-pbkdf": {
+                              "version": "1.0.1",
+                              "bundled": true,
+                              "optional": true,
+                              "requires": {
+                                "tweetnacl": "0.14.5"
+                              }
+                            },
+                            "dashdash": {
+                              "version": "1.14.1",
+                              "bundled": true,
+                              "requires": {
+                                "assert-plus": "1.0.0"
+                              }
+                            },
+                            "ecc-jsbn": {
+                              "version": "0.1.1",
+                              "bundled": true,
+                              "optional": true,
+                              "requires": {
+                                "jsbn": "0.1.1"
+                              }
+                            },
+                            "getpass": {
+                              "version": "0.1.7",
+                              "bundled": true,
+                              "requires": {
+                                "assert-plus": "1.0.0"
+                              }
+                            },
+                            "jsbn": {
+                              "version": "0.1.1",
+                              "bundled": true,
+                              "optional": true
+                            },
+                            "tweetnacl": {
+                              "version": "0.14.5",
+                              "bundled": true,
+                              "optional": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "bundled": true
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "bundled": true
+                    },
+                    "mime-types": {
+                      "version": "2.1.18",
+                      "bundled": true,
+                      "requires": {
+                        "mime-db": "1.33.0"
+                      },
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.33.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "bundled": true
+                    },
+                    "performance-now": {
+                      "version": "0.2.0",
+                      "bundled": true
+                    },
+                    "qs": {
+                      "version": "6.4.0",
+                      "bundled": true
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.1",
+                      "bundled": true
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "bundled": true
+                    },
+                    "tough-cookie": {
+                      "version": "2.3.4",
+                      "bundled": true,
+                      "requires": {
+                        "punycode": "1.4.1"
+                      },
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.4.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.6.0",
+                      "bundled": true,
+                      "requires": {
+                        "safe-buffer": "5.1.1"
+                      }
+                    },
+                    "uuid": {
+                      "version": "3.2.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.2",
+                  "bundled": true,
+                  "requires": {
+                    "glob": "7.1.2"
+                  },
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.1.2",
+                      "bundled": true,
+                      "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                      },
+                      "dependencies": {
+                        "fs.realpath": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "inflight": {
+                          "version": "1.0.6",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0",
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true
+                        },
+                        "minimatch": {
+                          "version": "3.0.4",
+                          "bundled": true,
+                          "requires": {
+                            "brace-expansion": "1.1.11"
+                          },
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.11",
+                              "bundled": true,
+                              "requires": {
+                                "balanced-match": "1.0.0",
+                                "concat-map": "0.0.1"
+                              },
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "5.5.0",
+                  "bundled": true
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "block-stream": "0.0.9",
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3"
+                  },
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.9",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3"
+                      }
+                    },
+                    "fstream": {
+                      "version": "1.0.11",
+                      "bundled": true,
+                      "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.11",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tar-pack": {
+                  "version": "3.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "debug": "2.6.9",
+                    "fstream": "1.0.11",
+                    "fstream-ignore": "1.0.5",
+                    "once": "1.4.0",
+                    "readable-stream": "2.3.6",
+                    "rimraf": "2.6.2",
+                    "tar": "2.2.1",
+                    "uid-number": "0.0.6"
+                  },
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.6.9",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "fstream": {
+                      "version": "1.0.11",
+                      "bundled": true,
+                      "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.11",
+                          "bundled": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.5",
+                      "bundled": true,
+                      "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                      },
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true
+                        },
+                        "minimatch": {
+                          "version": "3.0.4",
+                          "bundled": true,
+                          "requires": {
+                            "brace-expansion": "1.1.11"
+                          },
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.11",
+                              "bundled": true,
+                              "requires": {
+                                "balanced-match": "1.0.0",
+                                "concat-map": "0.0.1"
+                              },
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.3.6",
+                      "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "process-nextick-args": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        },
+                        "safe-buffer": {
+                          "version": "5.1.1",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "1.1.1",
+                          "bundled": true,
+                          "requires": {
+                            "safe-buffer": "5.1.1"
+                          }
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "mapnik-vector-tile": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/mapnik-vector-tile/-/mapnik-vector-tile-1.6.1.tgz",
+          "integrity": "sha1-Pf8n1eTx/MZH1ljqislZEh8zn1k="
+        },
+        "nan": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+        }
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "assert-diff": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/assert-diff/-/assert-diff-0.0.4.tgz",
+      "integrity": "sha1-vxgcFXXVrXxz34B2pon0rhmVFgg=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.1.4",
+        "json-diff": "0.3.1"
+      }
+    },
+    "assert-plus": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.4.tgz",
+      "integrity": "sha1-KD7/ixQOzXaFKfvzcwpMCevsYfc=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-equal": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.2.tgz",
+      "integrity": "sha1-7Lt5D1aNQAmKYkK1SAXHWAXrk48=",
+      "dev": true
+    },
+    "bunker": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+      "integrity": "sha1-yImSRkqOKm7ehpMDdfkrWAd++Xw=",
+      "dev": true,
+      "requires": {
+        "burrito": "0.2.12"
+      }
+    },
+    "burrito": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+      "integrity": "sha1-0NbmrIHV6ZeJxvpKzLCwAx6lT2s=",
+      "dev": true,
+      "requires": {
+        "traverse": "0.5.2",
+        "uglify-js": "1.1.1"
+      },
+      "dependencies": {
+        "traverse": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+          "integrity": "sha1-4gPFjV9/DjfbbnTArLkpuwm2HYU=",
+          "dev": true
+        }
+      }
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "charm": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+      "integrity": "sha1-BsIe7RobBq62dVPNxT4jJ0usIpY=",
+      "dev": true
+    },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+    },
+    "cli-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
+      "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.8.2"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+      "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
+      "integrity": "sha1-mWedO70EcVb81FDT0B7rkGhpHoM=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
+    "difflet": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+      "integrity": "sha1-qyOzH1ZJtvqo49KsvTNEZzZcpvo=",
+      "dev": true,
+      "requires": {
+        "charm": "0.1.2",
+        "deep-is": "0.1.3",
+        "traverse": "0.6.6"
+      }
+    },
+    "difflib": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+      "dev": true,
+      "requires": {
+        "heap": "0.2.6"
+      }
+    },
+    "dreamopt": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
+      "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
+      "dev": true,
+      "requires": {
+        "wordwrap": "1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "err-code": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-0.1.2.tgz",
+      "integrity": "sha1-EiqSszQrmJnaArWsmU0w+V1HY+4="
+    },
+    "es5-ext": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
+      "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.20"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "requires": {
+        "minipass": "2.3.4"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
+      }
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimatch": "0.3.0"
+      }
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.18.0",
+        "is-my-json-valid": "2.19.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "requires": {
+        "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        }
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.3.1",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        }
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-diff": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz",
+      "integrity": "sha1-bbw64tJeB1p/1xvNmHRFhmb7aBs=",
+      "dev": true,
+      "requires": {
+        "cli-color": "0.1.7",
+        "difflib": "0.2.4",
+        "dreamopt": "0.6.0"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "maki": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/maki/-/maki-0.5.0.tgz",
+      "integrity": "sha1-zs/mXdjclgeOXls5A2T0ygQgaRY="
+    },
+    "mapnik": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-4.0.1.tgz",
+      "integrity": "sha512-iVlsplv9fAJG6E3+hAUT5eNDZ5ZuEr4+Libc70C8On+Sh381rnbh56Q5dxO89DQw6Zhd4sKD5QtIxtyncWddjA==",
+      "requires": {
+        "mapnik-vector-tile": "2.2.1",
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.3"
+      }
+    },
+    "mapnik-vector-tile": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/mapnik-vector-tile/-/mapnik-vector-tile-2.2.1.tgz",
+      "integrity": "sha512-+oasa2DfqArIMC7F71ca8CXpDt0rEcq9sJDv+AuhBCZJg+3m2ikDAs/oskEpPpUOwta1hH48Qr+0deCkyB/0Jg=="
+    },
+    "mime-db": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.36.0"
+      }
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "minipass": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
+      "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+      "requires": {
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
+      }
+    },
+    "minizlib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "requires": {
+        "minipass": "2.3.4"
+      }
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
+    "needle": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.3.tgz",
+      "integrity": "sha512-GPL22d/U9cai87FcCPO6e+MT3vyHS2j+zwotakDc7kE2DtUAqFKMXLJCTtRp+5S75vXIwQPvIxkvlctxf9q4gQ==",
+      "requires": {
+        "debug": "2.6.9",
+        "iconv-lite": "0.4.24",
+        "sax": "1.2.4"
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
+      "requires": {
+        "detect-libc": "1.0.3",
+        "mkdirp": "0.5.1",
+        "needle": "2.2.3",
+        "nopt": "4.0.1",
+        "npm-packlist": "1.1.11",
+        "npmlog": "4.1.2",
+        "rc": "1.2.8",
+        "rimraf": "2.6.2",
+        "semver": "5.5.1",
+        "tar": "4.4.6"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        }
+      }
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+      "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "npm-bundled": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
+    },
+    "npm-packlist": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.11.tgz",
+      "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
+      "requires": {
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.5"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "protozero": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/protozero/-/protozero-1.5.1.tgz",
+      "integrity": "sha1-Wiffb7bh7XQ/UQgSrnbAgvWxZjg="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.78.0",
+      "resolved": "http://registry.npmjs.org/request/-/request-2.78.0.tgz",
+      "integrity": "sha1-4cjew0bhyBkjskrNszfxHeyr6cw=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.8.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.20",
+        "node-uuid": "1.4.8",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.6",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.4.3"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        }
+      }
+    },
+    "runforcover": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+      "integrity": "sha1-NE8FfY1F0zrrxsyCIEZ49pxIV8w=",
+      "dev": true,
+      "requires": {
+        "bunker": "0.1.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semver": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "tap": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
+      "integrity": "sha1-OYYTTWdZcn/CIj5hEm7rhyQ6zLw=",
+      "dev": true,
+      "requires": {
+        "buffer-equal": "0.0.2",
+        "deep-equal": "0.0.0",
+        "difflet": "0.2.6",
+        "glob": "3.2.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.3.5",
+        "nopt": "2.2.1",
+        "runforcover": "0.0.2",
+        "slide": "1.1.6",
+        "yamlish": "0.0.7"
+      }
+    },
+    "tar": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
+      "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
+      "requires": {
+        "chownr": "1.1.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.3.4",
+        "minizlib": "1.1.0",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "uglify-js": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+      "integrity": "sha1-7nGpfEzv0GoamyBDfzQRiYKqA1s=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+      "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+    },
+    "yallist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+    },
+    "yamlish": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz",
+      "integrity": "sha1-tK+aHcxjYYhzw9bkUewyE8OaV/s=",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/makizushi",
-  "version": "2.0.0",
+  "version": "2.0.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "test": "test"
   },
   "dependencies": {
-    "err-code": "0.1.2",
     "@mapbox/blend": "~2.0.0",
+    "err-code": "0.1.2",
     "maki": "0.5.0",
-    "xtend": "~3.0.0",
-    "mapnik": "~3.7.0"
+    "mapnik": "^4.0.1",
+    "xtend": "~3.0.0"
   },
   "devDependencies": {
     "@mapbox/assert-http": "~1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/makizushi",
-  "version": "2.0.1-0",
+  "version": "2.0.1-1",
   "description": "professional maki chef",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/makizushi",
-  "version": "2.0.0",
+  "version": "2.0.1-0",
   "description": "professional maki chef",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "xtend": "~3.0.0"
   },
   "devDependencies": {
-    "@mapbox/assert-http": "~1.1.4",
+    "@mapbox/assert-http": "^2.0.0",
     "tap": "~0.4.8"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@mapbox/blend": "~2.0.0",
+    "@mapbox/blend": "^2.0.1-0",
     "err-code": "0.1.2",
     "maki": "0.5.0",
     "mapnik": "^4.0.1",


### PR DESCRIPTION
- also adds a package-lock.json 
- travis tests on node versions 6 and 8, not 0.10 and 4
- bumps makizushi to version 3, as tests for node v0.10 with mapnik4 
